### PR TITLE
Parse hours, SIREN and SIRET as text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dbs/*.db
 *.pyc
 build/
 dist/
+reports/
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Upgrade to Quart-0.9.1 :warning: requires python-3.7 [#21](https://github.com/opendatateam/csvapi/pull/21)
+- Parse hours, SIREN and SIRET as text [#42](https://github.com/opendatateam/csvapi/pull/42)
 
 ## 0.0.9 (2019-01-18)
 

--- a/csvapi/parser.py
+++ b/csvapi/parser.py
@@ -2,7 +2,6 @@ import os
 
 import agate
 import agatesql  # noqa
-
 import cchardet as chardet
 
 from csvapi.utils import get_db_info

--- a/csvapi/parser.py
+++ b/csvapi/parser.py
@@ -2,9 +2,11 @@ import os
 
 import agate
 import agatesql  # noqa
+
 import cchardet as chardet
 
 from csvapi.utils import get_db_info
+from csvapi.type_tester import agate_tester
 
 SNIFF_LIMIT = 4096
 
@@ -22,14 +24,14 @@ def detect_encoding(filepath):
 def from_csv(filepath, encoding='utf-8', sniff_limit=SNIFF_LIMIT):
     """Try first w/ sniffing and then w/o sniffing if it fails"""
     try:
-        return agate.Table.from_csv(filepath, sniff_limit=sniff_limit, encoding=encoding)
+        return agate.Table.from_csv(filepath, sniff_limit=sniff_limit, encoding=encoding, column_types=agate_tester())
     except ValueError:
-        return agate.Table.from_csv(filepath, encoding=encoding)
+        return agate.Table.from_csv(filepath, encoding=encoding, column_types=agate_tester())
 
 
 def from_excel(filepath):
     import agateexcel  # noqa
-    return agate.Table.from_xls(filepath)
+    return agate.Table.from_xls(filepath, column_types=agate_tester())
 
 
 def to_sql(table, urlhash, storage):

--- a/csvapi/type_tester.py
+++ b/csvapi/type_tester.py
@@ -1,8 +1,6 @@
 import re
 
-from agatesql import table as agatesqltable
 from agate.data_types.base import DataType
-from agate.type_tester import TypeTester
 from agate.data_types.boolean import Boolean
 from agate.data_types.date import Date
 from agate.data_types.date_time import DateTime
@@ -10,6 +8,10 @@ from agate.data_types.number import Number
 from agate.data_types.text import Text
 from agate.data_types.time_delta import TimeDelta
 from agate.exceptions import CastError
+from agate.type_tester import TypeTester
+
+from agatesql import table as agatesqltable
+
 from sqlalchemy.types import VARCHAR
 
 from stdnum.fr.siren import is_valid as is_valid_siren
@@ -17,6 +19,8 @@ from stdnum.fr.siret import is_valid as is_valid_siret
 
 
 class Time(DataType):
+    # Detect an hour minute string.
+    # Examples: 12:20, 9:50, 23:30
     def __init__(self, **kwargs):
         super(Time, self).__init__(**kwargs)
 
@@ -30,6 +34,7 @@ class Time(DataType):
 
 
 class SirenSiret(DataType):
+    # Detect a SIREN or SIRET number
     def __init__(self):
         super(SirenSiret, self).__init__()
 

--- a/csvapi/type_tester.py
+++ b/csvapi/type_tester.py
@@ -12,6 +12,9 @@ from agate.data_types.time_delta import TimeDelta
 from agate.exceptions import CastError
 from sqlalchemy.types import VARCHAR
 
+from stdnum.fr.siren import is_valid as is_valid_siren
+from stdnum.fr.siret import is_valid as is_valid_siret
+
 
 class Time(DataType):
     def __init__(self, **kwargs):
@@ -26,10 +29,30 @@ class Time(DataType):
         raise CastError('Can not parse value "%s" as time.' % d)
 
 
+class SirenSiret(DataType):
+    def __init__(self):
+        super(SirenSiret, self).__init__()
+
+    def cast(self, d):
+        if is_valid_siret(d) or is_valid_siren(d):
+            return Text().cast(d)
+        raise CastError('Can not parse value "%s" as a SIREN or SIRET.' % d)
+
+
 agatesqltable.SQL_TYPE_MAP[Time] = VARCHAR
+agatesqltable.SQL_TYPE_MAP[SirenSiret] = VARCHAR
 
 
 def agate_tester():
     return TypeTester(
-        types=[Boolean(), Number(), Time(), TimeDelta(), Date(), DateTime(), Text()]
+        types=[
+            Boolean(),
+            SirenSiret(),
+            Number(),
+            Time(),
+            TimeDelta(),
+            Date(),
+            DateTime(),
+            Text(),
+        ]
     )

--- a/csvapi/type_tester.py
+++ b/csvapi/type_tester.py
@@ -26,9 +26,6 @@ class Time(DataType):
 
     def cast(self, d):
         if re.match(r"^(?:[01]\d|2[0-3]|\d):[0-5]\d$", d):
-            # Zero pad hour (case like 9:41)
-            if len(d) == 4:
-                return Text().cast(f"0{d}")
             return Text().cast(d)
         raise CastError('Can not parse value "%s" as time.' % d)
 
@@ -44,11 +41,21 @@ class SirenSiret(DataType):
         raise CastError('Can not parse value "%s" as a SIREN or SIRET.' % d)
 
 
+# agatesql needs to know the SQL equivalent of a type.
+# Tell agatesql how our custom types should be converted in SQL.
+#
+# Reference:
+# https://github.com/wireservice/agate-sql/blob/7466073d81289323851c21817ea33170e36ce2a5/agatesql/table.py#L21-L28
 agatesqltable.SQL_TYPE_MAP[Time] = VARCHAR
 agatesqltable.SQL_TYPE_MAP[SirenSiret] = VARCHAR
 
 
 def agate_tester():
+    # Override the original list of type checkers present in agate
+    # to detect types.
+    #
+    # Original list here:
+    # https://github.com/wireservice/agate/blob/e3078dca8b3566e8408e65981f79918c2f36f9fe/agate/type_tester.py#L64-L71
     return TypeTester(
         types=[
             Boolean(),

--- a/csvapi/type_tester.py
+++ b/csvapi/type_tester.py
@@ -1,0 +1,30 @@
+import re
+
+from agate.data_types.base import DataType
+from agate.type_tester import TypeTester
+from agate.data_types.boolean import Boolean
+from agate.data_types.date import Date
+from agate.data_types.date_time import DateTime
+from agate.data_types.number import Number
+from agate.data_types.text import Text
+from agate.data_types.time_delta import TimeDelta
+from agate.exceptions import CastError
+
+
+class Time(DataType):
+    def __init__(self, **kwargs):
+        super(Time, self).__init__(**kwargs)
+
+    def cast(self, d):
+        if re.match(r"^(?:[01]\d|2[0-3]|\d):[0-5]\d$", d):
+            # Zero pad hour (case like 9:41)
+            if len(d) == 4:
+                return Text().cast(f"0{d}")
+            return Text().cast(d)
+        raise CastError('Can not parse value "%s" as time.' % d)
+
+
+def agate_tester():
+    return TypeTester(
+        types=[Boolean(), Number(), Time(), TimeDelta(), Date(), DateTime(), Text()]
+    )

--- a/csvapi/type_tester.py
+++ b/csvapi/type_tester.py
@@ -1,5 +1,6 @@
 import re
 
+from agatesql import table as agatesqltable
 from agate.data_types.base import DataType
 from agate.type_tester import TypeTester
 from agate.data_types.boolean import Boolean
@@ -9,6 +10,7 @@ from agate.data_types.number import Number
 from agate.data_types.text import Text
 from agate.data_types.time_delta import TimeDelta
 from agate.exceptions import CastError
+from sqlalchemy.types import VARCHAR
 
 
 class Time(DataType):
@@ -22,6 +24,9 @@ class Time(DataType):
                 return Text().cast(f"0{d}")
             return Text().cast(d)
         raise CastError('Can not parse value "%s" as time.' % d)
+
+
+agatesqltable.SQL_TYPE_MAP[Time] = VARCHAR
 
 
 def agate_tester():

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -8,3 +8,4 @@ agate-excel==0.2.3
 Quart==0.9.1
 raven==6.10.0
 cchardet==2.1.4
+python-stdnum==1.11

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,10 @@ b<sep>522816651<sep>52281665100056
 """
 
 
+def random_url():
+    return f"https://example.com/{uuid.uuid4()}.csv"
+
+
 @pytest.fixture
 @pytest.mark.asyncio
 async def uploaded_csv(rmock, csv, client):
@@ -126,7 +131,7 @@ async def test_apify_col_mismatch(rmock, csv_col_mismatch, client):
 @pytest.mark.asyncio
 async def test_apify_hour_format(rmock, csv_hour, client):
     content = csv_hour.replace('<sep>', ';').encode('utf-8')
-    url = 'http://example.com/file.csv'
+    url = random_url()
     rmock.get(url, content=content)
     await client.get('/apify?url={}'.format(url))
     res = await client.get('/api/{}'.format(get_hash(url)))
@@ -136,7 +141,7 @@ async def test_apify_hour_format(rmock, csv_hour, client):
     assert jsonres['total'] == 3
     assert jsonres['rows'] == [
         [1, 'a', '12:30'],
-        [2, 'b', '09:15'],
+        [2, 'b', '9:15'],
         [3, 'c', '09:45'],
     ]
 
@@ -144,7 +149,7 @@ async def test_apify_hour_format(rmock, csv_hour, client):
 @pytest.mark.asyncio
 async def test_apify_siren_siret_format(rmock, csv_siren_siret, client):
     content = csv_siren_siret.replace('<sep>', ';').encode('utf-8')
-    url = 'http://example.com/siren_siret.csv'
+    url = random_url()
     rmock.get(url, content=content)
     await client.get('/apify?url={}'.format(url))
     res = await client.get('/api/{}'.format(get_hash(url)))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,14 @@ c<sep>09:45
 
 
 @pytest.fixture
+def csv_siren_siret():
+    return """id<sep>siren<sep>siret
+a<sep>130025265<sep>13002526500013
+b<sep>522816651<sep>52281665100056
+"""
+
+
+@pytest.fixture
 @pytest.mark.asyncio
 async def uploaded_csv(rmock, csv, client):
     content = csv.replace('<sep>', ';').encode('utf-8')
@@ -130,6 +138,23 @@ async def test_apify_hour_format(rmock, csv_hour_content, client):
         [1, 'a', '12:30'],
         [2, 'b', '09:15'],
         [3, 'c', '09:45'],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apify_siren_siret_format(rmock, csv_siren_siret, client):
+    content = csv_siren_siret.replace('<sep>', ';').encode('utf-8')
+    url = 'http://example.com/siren_siret.csv'
+    rmock.get(url, content=content)
+    await client.get('/apify?url={}'.format(url))
+    res = await client.get('/api/{}'.format(get_hash(url)))
+    assert res.status_code == 200
+    jsonres = await res.json
+    assert jsonres['columns'] == ['rowid', 'id', 'siren', 'siret']
+    assert jsonres['total'] == 2
+    assert jsonres['rows'] == [
+        [1, 'a', '130025265', '13002526500013'],
+        [2, 'b', '522816651', '52281665100056'],
     ]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,7 @@ data ª2<sep>data b2<sep>4<sep>
 
 
 @pytest.fixture
-def csv_hour_content():
+def csv_hour():
     return '''id<sep>hour
 a<sep>12:30
 b<sep>9:15
@@ -124,8 +124,8 @@ async def test_apify_col_mismatch(rmock, csv_col_mismatch, client):
 
 
 @pytest.mark.asyncio
-async def test_apify_hour_format(rmock, csv_hour_content, client):
-    content = csv_hour_content.replace('<sep>', ';').encode('utf-8')
+async def test_apify_hour_format(rmock, csv_hour, client):
+    content = csv_hour.replace('<sep>', ';').encode('utf-8')
     url = 'http://example.com/file.csv'
     rmock.get(url, content=content)
     await client.get('/apify?url={}'.format(url))


### PR DESCRIPTION
Related to #41.

Detect values that should be treated as strings and force a string casting. This PR introduces a custom type checker for `agate` to recognise hours, SIREN and SIRET.