### PR TITLE
Add pandas-profiling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dbs/*.db
+profiles/*.html
 *.egg-info/
 *.pyc
 build/

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 DB_ROOT_DIR = './dbs'
+PROFILES_ROOT_DIR = './profiles'
 CSV_CACHE_ENABLED = True
 MAX_WORKERS = 3
 DEBUG = True
@@ -13,3 +14,4 @@ MAX_FILE_SIZE = 1024 * 1024 * 100
 # It will also match subdomains
 # e.g. REFERRERS_FILTER = ['data.gouv.fr'] will match 'demo.data.gouv.fr'
 REFERRERS_FILTER = None
+PANDAS_PROFILING_CONFIG_MIN = False

--- a/csvapi/parseview.py
+++ b/csvapi/parseview.py
@@ -69,5 +69,6 @@ class ParseView(MethodView):
         scheme = 'https' if app.config.get('FORCE_SSL') else request.scheme
         return jsonify({
             'ok': True,
-            'endpoint': f"{scheme}://{request.host}/api/{urlhash}"
+            'endpoint': f"{scheme}://{request.host}/api/{urlhash}",
+            'profile_endpoint': f"{scheme}://{request.host}/profile/{urlhash}",
         })

--- a/csvapi/profileview.py
+++ b/csvapi/profileview.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pandas as pd
+import sqlite3
+
+from quart import send_from_directory
+from quart.views import MethodView
+from pandas_profiling import ProfileReport
+
+from csvapi.errors import APIError
+from csvapi.utils import get_db_info
+
+from quart import current_app as app
+
+
+class ProfileView(MethodView):
+
+    def make_profile(self, db_info):
+        dsn = 'file:{}?immutable=1'.format(db_info['db_path'])
+        conn = sqlite3.connect(dsn)
+        sql = 'SELECT * FROM [{}]'.format(db_info['table_name'])
+        df = pd.read_sql(sql, con=conn)
+        if(app.config['PANDAS_PROFILING_CONFIG_MIN']):
+            profile = ProfileReport(df, config_file="profiling-minimal.yml")
+        else:
+            profile = ProfileReport(df)
+        profile.to_file(db_info['profile_path'])
+        return Path(db_info['profile_path'])
+
+    async def get(self, urlhash):
+        db_info = get_db_info(urlhash)
+        p = Path(db_info['db_path'])
+        if not p.exists():
+            raise APIError('Database has probably been removed or does not exist yet.', status=404)
+
+        path = Path(db_info['profile_path'])
+
+        if not path.exists():
+            try:
+                path = self.make_profile(db_info)
+            except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
+                raise APIError('Error selecting data', status=400, payload=dict(details=str(e)))
+
+        return await send_from_directory(path.parent, path.name)

--- a/csvapi/tableview.py
+++ b/csvapi/tableview.py
@@ -5,9 +5,9 @@ import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-
 from quart import request, jsonify, current_app as app
 from quart.views import MethodView
+from slugify import slugify
 
 from csvapi.errors import APIError
 from csvapi.utils import get_db_info
@@ -69,12 +69,13 @@ class TableView(MethodView):
         for (f_key, f_value) in filters:
             comparator = f_key.split('__')[1]
             column = f_key.split('__')[0]
+            normalized_column = slugify(column, separator='_')
             if comparator == 'exact':
-                wheres.append(f"[{column}] = :filter_value_{column}")
-                params[f'filter_value_{column}'] = f_value
+                wheres.append(f"[{column}] = :filter_value_{normalized_column}")
+                params[f'filter_value_{normalized_column}'] = f_value
             elif comparator == 'contains':
-                wheres.append(f"[{column}] LIKE :filter_value_{column}")
-                params[f'filter_value_{column}'] = f'%{f_value}%'
+                wheres.append(f"[{column}] LIKE :filter_value_{normalized_column}")
+                params[f'filter_value_{normalized_column}'] = f'%{f_value}%'
             else:
                 app.logger.warning(f'Dropped unknown comparator in {f_key}')
         if wheres:

--- a/csvapi/utils.py
+++ b/csvapi/utils.py
@@ -9,13 +9,16 @@ executor = None
 
 def get_db_info(urlhash, storage=None):
     # app.config not thread safe, sometimes we need to pass storage directly
-    storage = storage or app.config['DB_ROOT_DIR']
-    dbpath = f"{storage}/{urlhash}.db"
+    db_storage = storage or app.config['DB_ROOT_DIR']
+    profile_storage = app.config['PROFILES_ROOT_DIR']
+    db_path = f"{db_storage}/{urlhash}.db"
+    profile_path = f"{profile_storage}/{urlhash}.html"
     return {
-        'dsn': f"sqlite:///{dbpath}",
+        'dsn': f"sqlite:///{db_path}",
         'db_name': urlhash,
         'table_name': urlhash,
-        'db_path': dbpath,
+        'db_path': db_path,
+        'profile_path': profile_path,
     }
 
 

--- a/csvapi/webservice.py
+++ b/csvapi/webservice.py
@@ -10,12 +10,14 @@ from csvapi.tableview import TableView
 from csvapi.exportview import ExportView
 from csvapi.uploadview import UploadView
 from csvapi.parseview import ParseView
+from csvapi.profileview import ProfileView
 from csvapi.security import filter_referrers
 
 app = Quart(__name__)
 app = cors(app, allow_origin='*')
 
 app.add_url_rule('/api/<urlhash>', view_func=TableView.as_view('table'))
+app.add_url_rule('/profile/<urlhash>', view_func=ProfileView.as_view('profile'))
 app.add_url_rule('/api/<urlhash>/export', view_func=ExportView.as_view('export'))
 app.add_url_rule('/apify', view_func=ParseView.as_view('parse'))
 app.add_url_rule('/upload', view_func=UploadView.as_view('upload'))

--- a/profiling-minimal.yml
+++ b/profiling-minimal.yml
@@ -1,0 +1,193 @@
+# Title of the document
+title: "Pandas Profiling Report"
+
+# Metadata
+dataset:
+  description: ""
+  creator: ""
+  author: "Etalab"
+  copyright_holder: ""
+  copyright_year: ""
+  url: ""
+
+variables:
+  descriptions: {}
+
+# infer dtypes
+infer_dtypes: True
+
+# Show the description at each variable (in addition to the overview tab)
+show_variable_description: True
+
+# Number of workers (0=multiprocessing.cpu_count())
+pool_size: 0
+
+# Show the progress bar
+progress_bar: True
+
+# Per variable type description settings
+vars:
+    num:
+        quantiles:
+              - 0.05
+              - 0.25
+              - 0.5
+              - 0.75
+              - 0.95
+        skewness_threshold: 20
+        low_categorical_threshold: 5
+# Set to zero to disable
+        chi_squared_threshold: 0.0
+    cat:
+        length: False
+        characters: False
+        words: False
+        cardinality_threshold: 50
+        n_obs: 5
+# Set to zero to disable
+        chi_squared_threshold: 0.0
+        coerce_str_to_date: False
+        redact: False
+    bool:
+        n_obs: 3
+# string to boolean mappings pairs (true, false)
+        mappings:
+          - ["t", "f"]
+          - ["yes", "no"]
+          - ["y", "n"]
+          - ["true", "false"]
+    path:
+        active: False
+    file:
+        active: False
+    image:
+        active: False
+        exif: False
+        hash: False
+    url:
+        active: False
+
+
+# Sort the variables. Possible values: ascending, descending or None (leaves original sorting)
+sort: None
+
+# which diagrams to show
+missing_diagrams:
+    bar: False
+    matrix: False
+    heatmap: False
+    dendrogram: False
+
+correlations:
+    pearson:
+      calculate: False
+      warn_high_correlations: True
+      threshold: 0.9
+    spearman:
+      calculate: False
+      warn_high_correlations: False
+      threshold: 0.9
+    kendall:
+      calculate: False
+      warn_high_correlations: False
+      threshold: 0.9
+    phi_k:
+      calculate: False
+      warn_high_correlations: False
+      threshold: 0.9
+    cramers:
+      calculate: False
+      warn_high_correlations: True
+      threshold: 0.9
+
+
+# Bivariate / Pairwise relations
+interactions:
+  targets: []
+  continuous: False
+
+# For categorical
+categorical_maximum_correlation_distinct: 100
+
+# Plot-specific settings
+plot:
+# Image format (svg or png)
+    image_format: "svg"
+    dpi: 800
+
+    scatter_threshold: 1000
+
+    correlation:
+        cmap: 'RdBu'
+        bad: '#000000'
+
+    missing:
+        cmap: 'RdBu'
+# Force labels when there are > 50 variables
+# https://github.com/ResidentMario/missingno/issues/93#issuecomment-513322615
+        force_labels: True
+
+    pie:
+# display a pie chart if the number of distinct values is smaller or equal (set to 0 to disable)
+      max_unique: 0
+
+    histogram:
+        x_axis_labels: True
+
+# Number of bins (set to 0 to automatically detect the bin size)
+        bins: 50
+
+# Maximum number of bins (when bins=0)
+        max_bins: 250
+
+# The number of observations to show
+n_obs_unique: 5
+n_extreme_obs: 5
+n_freq_table_max: 10
+
+# Use `deep` flag for memory_usage
+memory_deep: False
+
+# Configuration related to the duplicates
+duplicates:
+    head: 0
+
+# Configuration related to the samples area
+samples:
+    head: 0
+    tail: 0
+    random: 0
+
+# Configuration related to the rejection of variables
+reject_variables: True
+
+# When in a Jupyter notebook
+notebook:
+    iframe:
+        height: '800px'
+        width: '100%'
+# or 'src'
+        attribute: 'srcdoc'
+
+html:
+# Minify the html
+    minify_html: True
+
+# Offline support
+    use_local_assets: True
+
+# If True, single file, else directory with assets
+    inline: True
+
+# Show navbar
+    navbar_show: True
+
+# For internal use
+    file_name: None
+
+# Styling options for the HTML report
+    style:
+      theme: None
+      logo: ""
+      primary_color: "#337ab7"
+      full_width: False

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -11,3 +11,5 @@ raven==6.10.0
 cchardet==2.1.7
 python-stdnum==1.15
 aiosqlite==0.16.1
+pandas==1.2.4
+pandas-profiling==2.11.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,10 +66,14 @@ c<sep>09:45
 
 @pytest.fixture
 def csv_filters():
-    return '''id,hour,value
-first,12:30,1
-second,9:15,2
-third,09:45,3
+    """
+    TODO: also test with unicode value in column name, but Quart
+    test client currently fails
+    """
+    return '''id,hour,value,another column
+first,12:30,1,value
+second,9:15,2,value
+third,09:45,3,value
 '''
 
 
@@ -405,7 +409,7 @@ async def test_api_filters_exact_hour(rmock, uploaded_csv_filters, client):
     jsonres = await res.json
     assert jsonres['total'] == 1
     assert jsonres['rows'] == [
-        [1, 'first', '12:30', 1.0],
+        [1, 'first', '12:30', 1.0, 'value'],
     ]
 
 
@@ -415,7 +419,7 @@ async def test_api_filters_contains_string(rmock, uploaded_csv_filters, client):
     jsonres = await res.json
     assert jsonres['total'] == 1
     assert jsonres['rows'] == [
-        [1, 'first', '12:30', 1.0],
+        [1, 'first', '12:30', 1.0, 'value'],
     ]
 
 
@@ -426,7 +430,7 @@ async def test_api_filters_contains_exact_int(rmock, uploaded_csv_filters, clien
     jsonres = await res.json
     assert jsonres['total'] == 1
     assert jsonres['rows'] == [
-        [1, 'first', '12:30', 1.0],
+        [1, 'first', '12:30', 1.0, 'value'],
     ]
 
 
@@ -436,7 +440,7 @@ async def test_api_filters_contains_exact_float(rmock, uploaded_csv_filters, cli
     jsonres = await res.json
     assert jsonres['total'] == 1
     assert jsonres['rows'] == [
-        [1, 'first', '12:30', 1.0],
+        [1, 'first', '12:30', 1.0, 'value'],
     ]
 
 
@@ -446,5 +450,15 @@ async def test_api_and_filters(rmock, uploaded_csv_filters, client):
     jsonres = await res.json
     assert jsonres['total'] == 1
     assert jsonres['rows'] == [
-        [1, 'first', '12:30', 1.0],
+        [1, 'first', '12:30', 1.0, 'value'],
+    ]
+
+
+async def test_api_filters_unnormalized_column(rmock, uploaded_csv_filters, client):
+    res = await client.get(f"/api/{MOCK_CSV_HASH_FILTERS}?id__contains=fir&another column__contains=value")
+    assert res.status_code == 200
+    jsonres = await res.json
+    assert jsonres['total'] == 1
+    assert jsonres['rows'] == [
+        [1, 'first', '12:30', 1.0, 'value'],
     ]


### PR DESCRIPTION
Simple support for `pandas-profiling`.

This leverages the existing csvapi mechanism and load the dataframe from DB after the CSV has been apified (bonus point: do not parse CSV twice).

Usage: call `/apify?url=xxx` then get the hash and call `/profile/{hash}.html`. It will be loaded from cache or generated (pretty slow).

I'm afraid this will make csvapi pretty slow :-/ but maybe we should give it a try.