### PR TITLE
Add filters "less than" or "greater than"  in API 

### DIFF
--- a/csvapi/tableview.py
+++ b/csvapi/tableview.py
@@ -79,11 +79,19 @@ class TableView(MethodView):
                 wheres.append(f"[{column}] LIKE :filter_value_{normalized_column}")
                 params[f'filter_value_{normalized_column}'] = f'%{f_value}%'
             elif comparator == 'less':
+                try:
+                    float_value = float(f_value)
+                except ValueError:
+                    raise APIError('Float value expected for less comparison.', status=400)
                 wheres.append(f"[{column}] <= :filter_value_l_{normalized_column}")
-                params[f'filter_value_l_{normalized_column}'] = float(f_value)
+                params[f'filter_value_l_{normalized_column}'] = float_value
             elif comparator == 'greater':
+                try:
+                    float_value = float(f_value)
+                except ValueError:
+                    raise APIError('Float value expected for greater comparison.', status=400)
                 wheres.append(f"[{column}] >= :filter_value_gt_{normalized_column}")
-                params[f'filter_value_gt_{normalized_column}'] = float(f_value)
+                params[f'filter_value_gt_{normalized_column}'] = float_value
             else:
                 app.logger.warning(f'Dropped unknown comparator in {f_key}')
         if wheres:

--- a/csvapi/tableview.py
+++ b/csvapi/tableview.py
@@ -72,7 +72,6 @@ class TableView(MethodView):
             comparator = f_key.split('__')[1]
             column = f_key.split('__')[0]
             normalized_column = slugify(column, separator='_')
-            print(f_value)
             if comparator == 'exact':
                 wheres.append(f"[{column}] = :filter_value_{normalized_column}")
                 params[f'filter_value_{normalized_column}'] = f_value
@@ -90,7 +89,6 @@ class TableView(MethodView):
         if wheres:
             sql += ' WHERE '
             sql += ' AND '.join(wheres)
-        print(params)
         return sql, params
 
     async def data(self, db_info, export=False):

--- a/csvapi/tableview.py
+++ b/csvapi/tableview.py
@@ -72,17 +72,25 @@ class TableView(MethodView):
             comparator = f_key.split('__')[1]
             column = f_key.split('__')[0]
             normalized_column = slugify(column, separator='_')
+            print(f_value)
             if comparator == 'exact':
                 wheres.append(f"[{column}] = :filter_value_{normalized_column}")
                 params[f'filter_value_{normalized_column}'] = f_value
             elif comparator == 'contains':
                 wheres.append(f"[{column}] LIKE :filter_value_{normalized_column}")
                 params[f'filter_value_{normalized_column}'] = f'%{f_value}%'
+            elif comparator == 'less':
+                wheres.append(f"[{column}] <= :filter_value_l_{normalized_column}")
+                params[f'filter_value_l_{normalized_column}'] = float(f_value)
+            elif comparator == 'greater':
+                wheres.append(f"[{column}] >= :filter_value_gt_{normalized_column}")
+                params[f'filter_value_gt_{normalized_column}'] = float(f_value)
             else:
                 app.logger.warning(f'Dropped unknown comparator in {f_key}')
         if wheres:
             sql += ' WHERE '
             sql += ' AND '.join(wheres)
+        print(params)
         return sql, params
 
     async def data(self, db_info, export=False):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -518,6 +518,16 @@ async def test_api_filters_less_greater_float(rmock, csv_numeric, client):
         [2, 'b', 4],
     ]
 
+async def test_api_filters_less_greater_string_error(rmock, csv_numeric, client):
+    content = csv_numeric.replace('<sep>', ';').encode('utf-8')
+    url = random_url()
+    rmock.get(url, body=content)
+    await client.get(f"/apify?url={url}")
+    res = await client.get(f"/api/{get_hash(url)}?value__greater=3&value__less=stan")
+    assert res.status_code == 400
+    jsonres = await res.json
+    assert jsonres == {"error":"Float value expected for less comparison.", "error_id": None , "ok":False}
+
 
 async def test_api_filters_unnormalized_column(rmock, uploaded_csv_filters, client):
     res = await client.get(f"/api/{MOCK_CSV_HASH_FILTERS}?id__contains=fir&another column__contains=value")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -514,7 +514,6 @@ async def test_api_filters_less_greater_float(rmock, csv_numeric, client):
     res = await client.get(f"/api/{get_hash(url)}?value__greater=3&value__less=10")
     assert res.status_code == 200
     jsonres = await res.json
-    print(jsonres)
     assert jsonres['rows'] == [
         [2, 'b', 4],
     ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -478,6 +478,48 @@ async def test_api_and_filters(rmock, uploaded_csv_filters, client):
     ]
 
 
+async def test_api_filters_greater_float(rmock, csv_numeric, client):
+    content = csv_numeric.replace('<sep>', ';').encode('utf-8')
+    url = random_url()
+    rmock.get(url, body=content)
+    await client.get(f"/apify?url={url}")
+    res = await client.get(f"/api/{get_hash(url)}?value__greater=10")
+    assert res.status_code == 200
+    jsonres = await res.json
+    print(jsonres)
+    assert jsonres['rows'] == [
+        [3, 'c', 12],
+    ]
+
+
+async def test_api_filters_less_float(rmock, csv_numeric, client):
+    content = csv_numeric.replace('<sep>', ';').encode('utf-8')
+    url = random_url()
+    rmock.get(url, body=content)
+    await client.get(f"/apify?url={url}")
+    res = await client.get(f"/api/{get_hash(url)}?value__less=3")
+    assert res.status_code == 200
+    jsonres = await res.json
+    print(jsonres)
+    assert jsonres['rows'] == [
+        [1, 'a', 2],
+    ]
+
+
+async def test_api_filters_less_greater_float(rmock, csv_numeric, client):
+    content = csv_numeric.replace('<sep>', ';').encode('utf-8')
+    url = random_url()
+    rmock.get(url, body=content)
+    await client.get(f"/apify?url={url}")
+    res = await client.get(f"/api/{get_hash(url)}?value__greater=3&value__less=10")
+    assert res.status_code == 200
+    jsonres = await res.json
+    print(jsonres)
+    assert jsonres['rows'] == [
+        [2, 'b', 4],
+    ]
+
+
 async def test_api_filters_unnormalized_column(rmock, uploaded_csv_filters, client):
     res = await client.get(f"/api/{MOCK_CSV_HASH_FILTERS}?id__contains=fir&another column__contains=value")
     assert res.status_code == 200


### PR DESCRIPTION
These new filters can be called using params in url (in the same way than `exact` and `contains` filters).

To have rows between two numeric values : 

`http://<DOMAIN_CSVAPI>/api/<URL_HASH>?<NAME_COLUMN>__greater=10&<NAME_COLUMN>__less=100`